### PR TITLE
stft_loss.py bug fix

### DIFF
--- a/utils/stft_loss.py
+++ b/utils/stft_loss.py
@@ -13,7 +13,7 @@ def stft(x, fft_size, hop_size, win_length, window):
     Returns:
         Tensor: Magnitude spectrogram (B, #frames, fft_size // 2 + 1).
     """
-    x_stft = torch.stft(x, fft_size, hop_size, win_length, window)
+    x_stft = torch.stft(x, fft_size, hop_size, win_length, window, return_complex=False)
     real = x_stft[..., 0]
     imag = x_stft[..., 1]
 


### PR DESCRIPTION
Hi Eloi, nice work you got here.

When in torch 2.0, the return_complex is required so the current stft function from stft_loss.py is broken, printing

RuntimeError: stft requires the return_complex parameter be given for real inputs, and will further require that return_complex=True in a future PyTorch release.

This pull fixes it.

Thanks

Wallace


